### PR TITLE
feat: enable non-const concat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ license = "MIT"
 keywords = ["array", "concat"]
 categories = ["data-structures", "no-std"]
 readme = "README.md"
+
+[features]
+const_panic = []

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # array-concat
 
-Macros for concatenating const arrays.
+Macros for concatenating arrays.
 
 To add to your Cargo.toml:
 ```toml
@@ -30,5 +30,10 @@ fn main() {
     assert_eq!([1, 2, 3, 4, 5], C);
     assert_eq!([1, 2, 3, 4, 5], c);
     assert_eq!([S(true), S(false)], F);
+
+    let a = [1, 2, 3];
+    let b = [4, 5];
+    let c = concat_arrays!(a, b); // Size is inferred by the assert below
+    assert_eq!([1, 2, 3, 4, 5], c);
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,27 +12,51 @@ macro_rules! concat_arrays_size {
 #[macro_export]
 macro_rules! concat_arrays {
     ($( $array:expr ),*) => ({
-        const __ARRAY_SIZE__: usize = $crate::concat_arrays_size!($($array),*);
-
         #[repr(C)]
-        struct ArrayConcatDecomposed<T>($([T; $array.len()]),*);
+        struct ArrayConcatDecomposed<T, A, B>(core::mem::ManuallyDrop<[T; 0]>, core::mem::ManuallyDrop<A>, core::mem::ManuallyDrop<B>);
 
-        #[repr(C)]
-        union ArrayConcatComposed<T, const N: usize> {
-            full: core::mem::ManuallyDrop<[T; N]>,
-            decomposed: core::mem::ManuallyDrop<ArrayConcatDecomposed<T>>,
+        impl<T> ArrayConcatDecomposed<T, [T; 0], [T; 0]> {
+            const fn default() -> Self {
+                Self::new(core::mem::ManuallyDrop::new([]), [])
+            }
         }
-
-        impl<T, const N: usize> ArrayConcatComposed<T, N> {
-            const fn have_same_size(&self) -> bool {
-                core::mem::size_of::<[T; N]>() == core::mem::size_of::<Self>()
+        impl<T, A, B> ArrayConcatDecomposed<T, A, B> {
+            const fn new(a: core::mem::ManuallyDrop<A>, b: B) -> Self {
+                Self(core::mem::ManuallyDrop::new([]), a, core::mem::ManuallyDrop::new(b))
+            }
+            const fn concat<const N: usize>(self, v: [T; N]) -> ArrayConcatDecomposed<T, A, ArrayConcatDecomposed<T, B, [T; N]>> {
+                ArrayConcatDecomposed::new(self.1, ArrayConcatDecomposed::new(self.2, v))
             }
         }
 
-        let composed = ArrayConcatComposed { decomposed: core::mem::ManuallyDrop::new(ArrayConcatDecomposed ( $($array),* ))};
+        #[repr(C)]
+        union ArrayConcatComposed<T, A, B, const N: usize> {
+            full: core::mem::ManuallyDrop<[T; N]>,
+            decomposed: core::mem::ManuallyDrop<ArrayConcatDecomposed<T, A, B>>,
+        }
+
+        impl<T, A, B, const N: usize> ArrayConcatComposed<T, A, B, N> {
+            const HAVE_SAME_SIZE: bool = core::mem::size_of::<[T; N]>() == core::mem::size_of::<Self>();
+
+            #[cfg(feature="const_panic")]
+            const PANIC: bool = Self::HAVE_SAME_SIZE || panic!("Size Mismatch");
+
+            #[cfg(not(feature="const_panic"))]
+            const PANIC: bool = !["Size mismatch"][!Self::HAVE_SAME_SIZE as usize].is_empty();
+
+            const fn have_same_size(&self) -> bool {
+                Self::PANIC
+            }
+        }
+
+        let composed = ArrayConcatComposed {
+            decomposed: core::mem::ManuallyDrop::new(
+                ArrayConcatDecomposed::default()$(.concat($array))*,
+            )
+        };
 
         // Sanity check that composed's two fields are the same size
-        ["Size mismatch"][!composed.have_same_size() as usize];
+        composed.have_same_size();
 
         // SAFETY: Sizes of both fields in composed are the same so this assignment should be sound
         core::mem::ManuallyDrop::into_inner(unsafe { composed.full })
@@ -69,6 +93,14 @@ mod tests {
         let f = concat_arrays!(A, C, [6, 7, 8]);
         const F: [u32; concat_arrays_size!(A, C, [6, 7, 8])] = concat_arrays!(A, C, [6, 7, 8]);
         assert_eq!([1, 2, 3, 4, 5, 6, 7, 8], F);
+        assert_eq!([1, 2, 3, 4, 5, 6, 7, 8], f);
+    }
+
+    #[test]
+    fn test_non_const_arrays() {
+        let a = [1, 2, 3];
+        let c = [4, 5];
+        let f = concat_arrays!(a, c, [6, 7, 8]);
         assert_eq!([1, 2, 3, 4, 5, 6, 7, 8], f);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,14 +16,17 @@ macro_rules! concat_arrays {
         struct ArrayConcatDecomposed<T, A, B>(core::mem::ManuallyDrop<[T; 0]>, core::mem::ManuallyDrop<A>, core::mem::ManuallyDrop<B>);
 
         impl<T> ArrayConcatDecomposed<T, [T; 0], [T; 0]> {
+            #[inline(always)]
             const fn default() -> Self {
                 Self::new(core::mem::ManuallyDrop::new([]), [])
             }
         }
         impl<T, A, B> ArrayConcatDecomposed<T, A, B> {
+            #[inline(always)]
             const fn new(a: core::mem::ManuallyDrop<A>, b: B) -> Self {
                 Self(core::mem::ManuallyDrop::new([]), a, core::mem::ManuallyDrop::new(b))
             }
+            #[inline(always)]
             const fn concat<const N: usize>(self, v: [T; N]) -> ArrayConcatDecomposed<T, A, ArrayConcatDecomposed<T, B, [T; N]>> {
                 ArrayConcatDecomposed::new(self.1, ArrayConcatDecomposed::new(self.2, v))
             }
@@ -44,6 +47,7 @@ macro_rules! concat_arrays {
             #[cfg(not(feature="const_panic"))]
             const PANIC: bool = !["Size mismatch"][!Self::HAVE_SAME_SIZE as usize].is_empty();
 
+            #[inline(always)]
             const fn have_same_size(&self) -> bool {
                 Self::PANIC
             }


### PR DESCRIPTION
Switch `ArrayConcatDecomposed` from a plain tuple to a more cons-like structure.

Make the const-panic slightly more robust, adding a feature to keep the MSRV low.

This should only require a patch version bump, as compatibility should be maintained with all previous callers.